### PR TITLE
Generic Identity Store

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -1,37 +1,39 @@
 import { KeyValueStore, Key } from '@liquid-state/iwa-keyvalue';
+import { Value } from '@liquid-state/iwa-keyvalue/dist/key';
 
 export interface ISerialisableIdentity {
   identity: string | null;
   credentials: object | null;
 }
 
-export interface IIdentityStore {
-  store(service: string, identity: ISerialisableIdentity): void;
-  fetch(service: string): Promise<ISerialisableIdentity>;
+export interface IIdentityStore<T extends Value = ISerialisableIdentity> {
+  store(service: string, identity: T): void;
+  fetch(service: string): Promise<T>;
 }
 
 export interface IIdentityStoreDelegate {
   setPermissionsForKey(key: Key): void;
 }
 
-export default class IdentityStore implements IIdentityStore {
+export default class IdentityStore<T extends Value = ISerialisableIdentity>
+  implements IIdentityStore<T> {
   private readonly BASE_KEY = 'identity';
 
   constructor(private keyValueStore: KeyValueStore, private delegate: IIdentityStoreDelegate) {}
 
-  store(service: string, identity: ISerialisableIdentity): void {
+  store(service: string, identity: T): void {
     let keyName = `${this.BASE_KEY}.${service}`;
     let key = new Key(keyName, identity);
     this.delegate.setPermissionsForKey(key);
     this.keyValueStore.set(key);
   }
 
-  async fetch(service: string): Promise<ISerialisableIdentity> {
+  async fetch(service: string): Promise<T> {
     let keyName = `${this.BASE_KEY}.${service}`;
     let key = await this.keyValueStore.get(keyName);
     if (!key.value) {
-      return { identity: null, credentials: null };
+      throw '';
     }
-    return key.decodeValue() as ISerialisableIdentity;
+    return key.decodeValue() as T;
   }
 }


### PR DESCRIPTION
This makes IdentityStore generic over the type of data which is stored under the identity key.
This enables us to work with the IdentityStore for providers which need more control over the type of data they are storing (instead of just abusing the identity + credentials object layout)